### PR TITLE
Store redirect_uri and state from initial oauth call

### DIFF
--- a/src/routes/oauth2/middleware.js
+++ b/src/routes/oauth2/middleware.js
@@ -35,6 +35,8 @@ module.exports = {
         });
 
         req.session.tokenId = apiResponse?.data["session_id"];
+        req.session.authParams.state = apiResponse?.data?.state;
+        req.session.authParams.redirect_uri = apiResponse?.data?.redirect_uri;
       }
       return next();
     } catch (error) {

--- a/src/routes/oauth2/middleware.test.js
+++ b/src/routes/oauth2/middleware.test.js
@@ -135,12 +135,14 @@ describe("oauth middleware", () => {
 
         expect(req.axios.post).to.have.been.calledWith("/api/authorize", {
           request: exampleJwt,
-          ...req.session.authParams,
+          client_id: req.session.authParams.client_id,
         });
       });
 
       context("with API result", () => {
         beforeEach(async () => {
+          response.data.state = "rAnd0m-i5ed_STring";
+          response.data.redirect_uri = "http://example.org:9001/callback";
           req.axios.post = sinon.fake.returns(response);
 
           await middleware.initSessionWithJWT(req, res, next);
@@ -150,6 +152,15 @@ describe("oauth middleware", () => {
           expect(req.session.tokenId).to.equal("abc1234");
         });
 
+        it("should save 'state' into req.session.authParams", () => {
+          expect(req.session.authParams.state).to.equal("rAnd0m-i5ed_STring");
+        });
+
+        it("should save 'redirect_uri' into req.session.authParams", () => {
+          expect(req.session.authParams.redirect_uri).to.equal(
+            "http://example.org:9001/callback"
+          );
+        });
         it("should call next", function () {
           expect(next).to.have.been.called;
         });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

`state` and `redirect_uri` are returned on a successful init session call. We should save them in our session so that we can use them for any error handling that needs to happen, as well as a successful return journey after the CRI has finished its main purpose.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
