### PR TITLE
fix: Use consistent redirect_uri instead of redirect_url

### DIFF
--- a/src/lib/oauth.js
+++ b/src/lib/oauth.js
@@ -1,6 +1,6 @@
 module.exports = {
   addOAuthPropertiesToSession: ({ authParams, data } = {}) => {
-    authParams.redirect_url = data.redirect_uri;
+    authParams.redirect_uri = data.redirect_uri;
     authParams.state = data.state;
 
     if (!data.code) {
@@ -16,7 +16,7 @@ module.exports = {
   },
   buildRedirectUrl: ({ authParams }) => {
     const authCode = authParams.authorization_code;
-    const url = authParams.redirect_url;
+    const url = authParams.redirect_uri;
     const state = authParams.state;
 
     let redirectUrl = new URL(url);

--- a/src/lib/oauth.test.js
+++ b/src/lib/oauth.test.js
@@ -10,12 +10,12 @@ describe("oauth lib", () => {
       data = {};
     });
 
-    it("should save 'redirect_url' to sessionModel", () => {
+    it("should save 'redirect_uri' to sessionModel", () => {
       data.redirect_uri = "http://example.net";
 
       addOAuthPropertiesToSession({ authParams, data });
 
-      expect(authParams.redirect_url).to.equal(data.redirect_uri);
+      expect(authParams.redirect_uri).to.equal(data.redirect_uri);
     });
 
     it("should save 'state' to sessionModel", () => {
@@ -52,9 +52,9 @@ describe("oauth lib", () => {
     let authParams;
     let redirectUrl;
 
-    it("should throw an error if redirect_url is not valid", () => {
+    it("should throw an error if redirect_uri is not valid", () => {
       authParams = {
-        redirect_url: "not-a-valid-url",
+        redirect_uri: "not-a-valid-url",
       };
 
       expect(() => buildRedirectUrl({ authParams }))
@@ -62,9 +62,9 @@ describe("oauth lib", () => {
         .with.property("code", "ERR_INVALID_URL");
     });
 
-    it("should use the redirect_url if valid", () => {
+    it("should use the redirect_uri if valid", () => {
       authParams = {
-        redirect_url: "http://example.org",
+        redirect_uri: "http://example.org",
       };
 
       buildRedirectUrl({ authParams });
@@ -73,7 +73,7 @@ describe("oauth lib", () => {
     context("with an authorization_code", () => {
       beforeEach(() => {
         authParams = {
-          redirect_url: "http://example.org",
+          redirect_uri: "http://example.org",
           authorization_code: "1234",
           state: "STATE",
           client_id: "client",
@@ -109,7 +109,7 @@ describe("oauth lib", () => {
           };
 
           authParams = {
-            redirect_url: "http://example.org",
+            redirect_uri: "http://example.org",
             error,
           };
         });

--- a/src/routes/oauth2/middleware.test.js
+++ b/src/routes/oauth2/middleware.test.js
@@ -197,7 +197,7 @@ describe("oauth middleware", () => {
         authParams: {
           client_id: clientId,
           authorization_code: code,
-          redirect_url: redirect,
+          redirect_uri: redirect,
           state,
         },
       };
@@ -232,7 +232,7 @@ describe("oauth middleware", () => {
     });
 
     it("should call next with URL error if redirect_uri not present", async () => {
-      delete req.session.authParams.redirect_url;
+      delete req.session.authParams.redirect_uri;
 
       await middleware.redirectToCallback(req, res, next);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

`redirect_url` (L) and `redirect_uri` (I) were being used inconsistently.

This PR aligns them to the oauth standard of `redirect_uri` (I)
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-XXXX](https://govukverify.atlassian.net/browse/KBV-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
