### PR TITLE
refactor: Rename API.AUTHORIZATON to API.SESSION to match backend

### DIFF
--- a/src/routes/oauth2/middleware.js
+++ b/src/routes/oauth2/middleware.js
@@ -21,15 +21,15 @@ module.exports = {
       return next(new Error("Missing client_id"));
     }
 
-    const authorizePath = req.app.get("API.PATHS.AUTHORIZE");
-    if (!authorizePath) {
-      return next(new Error("Missing API.PATHS.AUTHORIZE value"));
+    const sessionPath = req.app.get("API.PATHS.SESSION");
+    if (!sessionPath) {
+      return next(new Error("Missing API.PATHS.SESSION value"));
     }
 
     const requestJWT = req.jwt;
     try {
       if (requestJWT) {
-        const apiResponse = await req.axios.post(authorizePath, {
+        const apiResponse = await req.axios.post(sessionPath, {
           request: req.jwt,
           client_id: req.session.authParams.client_id,
         });

--- a/src/routes/oauth2/middleware.test.js
+++ b/src/routes/oauth2/middleware.test.js
@@ -109,15 +109,13 @@ describe("oauth middleware", () => {
         );
       });
 
-      it("should call next with an error when API.PATHS.AUTHORIZE is missing", async () => {
+      it("should call next with an error when API.PATHS.SESSION is missing", async () => {
         await middleware.initSessionWithJWT(req, res, next);
 
         expect(next).to.have.been.calledWith(
           sinon.match
             .instanceOf(Error)
-            .and(
-              sinon.match.has("message", "Missing API.PATHS.AUTHORIZE value")
-            )
+            .and(sinon.match.has("message", "Missing API.PATHS.SESSION value"))
         );
       });
     });
@@ -127,7 +125,7 @@ describe("oauth middleware", () => {
         req.app = {
           get: sinon.stub(),
         };
-        req.app.get.withArgs("API.PATHS.AUTHORIZE").returns("/api/authorize");
+        req.app.get.withArgs("API.PATHS.SESSION").returns("/api/authorize");
       });
 
       it("should call axios with the correct parameters", async function () {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Rename `AUTHORIZE` to `SESSION` to match the naming on the backend systems.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-XXXX](https://govukverify.atlassian.net/browse/KBV-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
