### PR TITLE
Add oauth redirect error handling

### DIFF
--- a/src/lib/error-handling.js
+++ b/src/lib/error-handling.js
@@ -1,0 +1,36 @@
+const oAuth = require("./oauth");
+
+const DEFAULT_ERROR_CODE = "server_error";
+const DEFAULT_ERROR_DESCRIPTION = "general error";
+
+module.exports = {
+  redirectAsErrorToCallback: async (err, req, res, next) => {
+    let error = {
+      code: DEFAULT_ERROR_CODE,
+      description: DEFAULT_ERROR_DESCRIPTION,
+    };
+
+    let redirect_uri = req.session.authParams.redirect_uri;
+
+    if (err.isAxiosError) {
+      const oauthError = err?.response?.data?.oauth_error;
+
+      error.code = oauthError?.error || error.code;
+      error.description = oauthError?.error_description || error.description;
+      redirect_uri = err?.response?.data?.redirect_uri || redirect_uri;
+    }
+
+    try {
+      const redirectUrl = oAuth.buildRedirectUrl({
+        authParams: {
+          error,
+          redirect_uri,
+        },
+      });
+
+      return res.redirect(redirectUrl.toString());
+    } catch (e) {
+      return next(e);
+    }
+  },
+};

--- a/src/lib/error-handling.test.js
+++ b/src/lib/error-handling.test.js
@@ -1,0 +1,156 @@
+const proxyquire = require("proxyquire");
+
+const oAuthStub = {};
+const { redirectAsErrorToCallback } = proxyquire("./error-handling", {
+  "./oauth": oAuthStub,
+});
+
+describe("error-handling", () => {
+  let req;
+  let res;
+  let next;
+  let err;
+
+  beforeEach(() => {
+    const setup = setupDefaultMocks();
+    req = setup.req;
+    res = setup.res;
+    next = setup.next;
+
+    req.session = {
+      authParams: { redirect_uri: "http://example.org" },
+    };
+
+    oAuthStub.buildRedirectUrl = sinon.fake();
+  });
+
+  describe("redirectAsErrorToCallback", () => {
+    context("with Axios error", () => {
+      beforeEach(() => {
+        err = {
+          isAxiosError: true,
+          response: {
+            data: {
+              redirect_uri: "http://error.example.org",
+              oauth_error: {
+                error_description: "Invalid request JWT",
+                error: "invalid_request_object",
+              },
+            },
+          },
+        };
+      });
+
+      it("should override error code if provided in response body", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              error: {
+                code: "invalid_request_object",
+              },
+            },
+          })
+        );
+      });
+
+      it("should override error description if provided in response body", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              error: {
+                description: "Invalid request JWT",
+              },
+            },
+          })
+        );
+      });
+
+      it("should override redirect_uri if provided in response body", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              redirect_uri: "http://error.example.org",
+            },
+          })
+        );
+      });
+
+      it("should use a default for error code", async () => {
+        delete err.response.data.oauth_error.error;
+
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              error: {
+                code: "server_error",
+              },
+            },
+          })
+        );
+      });
+      it("should use a default for error description", async () => {
+        delete err.response.data.oauth_error.error_description;
+
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              error: {
+                description: "general error",
+              },
+            },
+          })
+        );
+      });
+      it("should use a default for redirect_uri", async () => {
+        delete err.response.data.redirect_uri;
+
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              redirect_uri: "http://example.org",
+            },
+          })
+        );
+      });
+    });
+
+    context.skip("with default Error object", () => {
+      beforeEach(async () => {
+        err = new Error("error message");
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should build redirect with default error code and description", () => {
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith({
+          authParams: {
+            error: { code: "server_error", description: "general error" },
+            redirect_uri: "http://example.org",
+          },
+        });
+      });
+    });
+
+    context("with valid redirect url", () => {
+      it("should call res.redirect with url");
+      it("should not call next");
+    });
+
+    context("with invalid redirect url", () => {
+      it("should not call res.redirect");
+      it("should call next with err");
+    });
+  });
+});

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -3,4 +3,5 @@ module.exports = {
   oauth: require("./oauth"),
   redis: require("./redis"),
   scenarioHeaders: require("./scenario-headers"),
+  errorHandling: require("./error-handling"),
 };

--- a/src/lib/oauth.js
+++ b/src/lib/oauth.js
@@ -11,7 +11,7 @@ module.exports = {
 
       authParams.error = error;
     } else {
-      authParams.authorization_code = data.code;
+      authParams.authorization_code = data.code?.value || data.code;
     }
   },
   buildRedirectUrl: ({ authParams }) => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add generic error handling as an [Express error handler](https://expressjs.com/en/guide/error-handling.html).

This means that if there is an uncaught Axior error, or it is passed on, the error middleware will be able to use the API response for `error code`, `error message` & `redirect_uri` if available.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-XXXX](https://govukverify.atlassian.net/browse/KBV-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
