### PR TITLE
refactor: Use footer content from i18n files

### DIFF
--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -17,9 +17,9 @@
 {% block beforeContent %}
   {{ govukPhaseBanner({
     tag: {
-      text: "beta"
+      text: translate("govuk.phaseBanner.tag")
     },
-    html: 'This is a new service – your <a class="govuk-link" rel="noopener" target="_blank" href="https://signin.account.gov.uk/contact-us">feedback (opens in new tab)</a> will help us to improve it.'
+    html: translate("govuk.phaseBanner.content")
   }) }}
 
   {% block backLink %}
@@ -33,38 +33,9 @@
   {% endblock %}
 {% endblock %}
 
+{% set footerNavItems = translate("govuk.footerNavItems") %}
 {% block footer %}
-  {{ govukFooter({
-    meta: {
-      items: [
-        {
-          href: "/accessibility-statement",
-          attributes: { target: "_blank" },
-          text: 'general.footer.accessibilityStatement.linkText' | translate
-        },
-        {
-          href: "https://www.gov.uk/help/cookies",
-          attributes: { target: "_blank" },
-          text: 'general.footer.cookies.linkText' | translate
-        },
-        {
-          href: "/terms-and-conditions",
-          attributes: { target: "_blank" },
-          text: 'general.footer.terms.linkText' | translate
-        },
-        {
-          href: "/privacy-notice",
-          attributes: { target: "_blank" },
-          text: 'general.footer.privacy.linkText' | translate
-        },
-        {
-          href: "/contact-us?supportType=PUBLIC",
-          attributes: { target: "_blank" },
-          text: 'general.footer.support.linkText' | translate
-        }
-      ]
-    }
-  }) }}
+  {{ govukFooter( footerNavItems ) }}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -17,9 +17,9 @@
 {% block beforeContent %}
   {{ govukPhaseBanner({
     tag: {
-      text: "beta"
+      text: translate("govuk.phaseBanner.tag")
     },
-    html: 'This is a new service – your <a class="govuk-link" rel="noopener" target="_blank" href="https://signin.account.gov.uk/contact-us">feedback (opens in new tab)</a> will help us to improve it.'
+    html: translate("govuk.phaseBanner.content")
   }) }}
 
   {% block backLink %}
@@ -33,38 +33,9 @@
   {% endblock %}
 {% endblock %}
 
+{% set footerNavItems = translate("govuk.footerNavItems") %}
 {% block footer %}
-  {{ govukFooter({
-    meta: {
-      items: [
-        {
-          href: "/accessibility-statement",
-          attributes: { target: "_blank" },
-          text: 'general.footer.accessibilityStatement.linkText' | translate
-        },
-        {
-          href: "https://www.gov.uk/help/cookies",
-          attributes: { target: "_blank" },
-          text: 'general.footer.cookies.linkText' | translate
-        },
-        {
-          href: "/terms-and-conditions",
-          attributes: { target: "_blank" },
-          text: 'general.footer.terms.linkText' | translate
-        },
-        {
-          href: "/privacy-notice",
-          attributes: { target: "_blank" },
-          text: 'general.footer.privacy.linkText' | translate
-        },
-        {
-          href: "/contact-us?supportType=PUBLIC",
-          attributes: { target: "_blank" },
-          text: 'general.footer.support.linkText' | translate
-        }
-      ]
-    }
-  }) }}
+  {{ govukFooter( footerNavItems ) }}
 {% endblock %}
 
 {% block bodyEnd %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use footer / phaseBanner content from `i18n` rather than hardcode into template

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
