### PR TITLE
KBV 390 create-unrecoverable-error-page

### DIFF
--- a/src/components/unrecoverable-error.njk
+++ b/src/components/unrecoverable-error.njk
@@ -1,0 +1,26 @@
+{% extends "form-template.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% set hmpoPageKey = "error.unrecoverable" %}
+
+{% block mainContent %}
+  <h1 data-id="error-title">{{ translate("error.unrecoverable.title") }}</h1>
+
+  <p>{{ translate("error.unrecoverable.subTitle") }}</p>
+
+  <h2>{{ translate("error.unrecoverable.subHeading") }}</h2>
+
+  <div class="govuk-text">
+    <p>{{ translate("error.unrecoverable.description") }}</p>
+  </div>
+
+  {{ govukButton({
+    text: translate("error.unrecoverable.buttonText"),
+    href: translate("error.unrecoverable.buttonLink")
+  }) }}
+
+  <div>
+      <p><a href="https://signin.account.gov.uk/contact-us" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ contactMeLink }}</a></p>
+  </div>
+
+{% endblock %}
+


### PR DESCRIPTION
## Proposed changes

### What changed

Added a templated unrecoverable error page.
The text and components have been created using templates we can override the variables to give translations or alternative text.
For example in your project you could have a view like so 
```
{% extends "unrecoverable-error.njk" %}
{% set pageTitle = "not so unrecoverable" %}
```

### Why did it change

As part of the unrecoverable error handling, we should have error pages that portray more information.
By adding it to common-express we can reuse it across multiple CRIs
By using templates we can override text accordingly.

### Issue tracking
- [KBV-390](https://govukverify.atlassian.net/browse/KBV-390)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed