### PR TITLE
fix: Use original error in next()

### DIFF
--- a/src/lib/error-handling.js
+++ b/src/lib/error-handling.js
@@ -30,7 +30,7 @@ module.exports = {
 
       return res.redirect(redirectUrl.toString());
     } catch (e) {
-      return next(e);
+      return next(err);
     }
   },
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use the original error when displaying an error page.

### Why did it change

The code is currently relying on `URL` throwing, and then that error is passed on, which means all unhandled errors become URL parsing errors. Which is not helpful.

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
