### PR TITLE
Use per-request nonce

### DIFF
--- a/src/lib/helmet.js
+++ b/src/lib/helmet.js
@@ -1,3 +1,5 @@
+const { generateNonce } = require("./strings");
+
 module.exports = {
   contentSecurityPolicy: {
     directives: {
@@ -5,7 +7,10 @@ module.exports = {
       styleSrc: ["'self'"],
       scriptSrc: [
         "'self'",
-        (req) => `'nonce-${req.app.get("APP.GTM.SCRIPT_NONCE")}'`,
+        (req, res) => {
+          res.locals.cspNonce = res.locals.cspNonce || generateNonce();
+          return `'nonce-${res.locals.cspNonce}'`;
+        },
         "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
         "https://www.googletagmanager.com",
         "https://www.google-analytics.com",

--- a/src/lib/helmet.js
+++ b/src/lib/helmet.js
@@ -22,6 +22,7 @@ module.exports = {
         "https://www.googletagmanager.com",
         "https://www.google-analytics.com",
       ],
+      formAction: ["*"],
       objectSrc: ["'none'"],
       connectSrc: ["'self'", "https://www.google-analytics.com"],
     },

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -1,7 +1,6 @@
 module.exports = {
   getGTM: function (req, res, next) {
     res.locals.gtmId = req.app.get("APP.GTM.ID");
-    res.locals.cspNonce = req.app.get("APP.CSP_NONCE");
     res.locals.analyticsCookieDomain = req.app.get(
       "APP.GTM.ANALYTICS_COOKIE_DOMAIN"
     );

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -1,9 +1,6 @@
-const { generateNonce } = require("./strings");
-
 module.exports = {
-  setGTM: ({ app, id, cspNonce, analyticsCookieDomain }) => {
+  setGTM: ({ app, id, analyticsCookieDomain }) => {
     app.set("APP.GTM.ID", id);
-    app.set("APP.CSP_NONCE", cspNonce || generateNonce());
     app.set("APP.GTM.ANALYTICS_COOKIE_DOMAIN", analyticsCookieDomain);
   },
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

https://w3c.github.io/webappsec-csp/#security-nonces

> If a server delivers a [nonce-source](https://w3c.github.io/webappsec-csp/#grammardef-nonce-source) expression as part of a [policy](https://w3c.github.io/webappsec-csp/#content-security-policy-object), the server MUST generate a unique value each time it transmits a policy.

This PR changes the `nonce` from being an app level variable, to one being set on the request. This change is annoyingly needing to be made in the Helmet config itself due to the order in which middleware is applied. This could be improved with a future PR in the bootstrap app.

It also applies a loose rule on the formAction of `*`. This is due to the default of `'self'` being interpreted differently between Chrome and Firefox.

https://stackoverflow.com/questions/69433198/form-action-csp-blocking-allowed-url

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-562](https://govukverify.atlassian.net/browse/KBV-562)
- [KBV-599](https://govukverify.atlassian.net/browse/KBV-599)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
