### PR TITLE
LIME-86 - Updating Phase banner to be contained in landmarks

### DIFF
--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -21,7 +21,10 @@
     tag: {
       text: translate("govuk.phaseBanner.tag")
     },
-    html: translate("govuk.phaseBanner.content")
+    html: translate("govuk.phaseBanner.content"),
+    attributes: {
+      "role": "complementary"
+    }
   }) }}
 
   {% block backLink %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -21,7 +21,10 @@
     tag: {
       text: translate("govuk.phaseBanner.tag")
     },
-    html: translate("govuk.phaseBanner.content")
+     html: translate("govuk.phaseBanner.content"),
+     attributes: {
+        "role": "complementary"
+     }
   }) }}
 
   {% block backLink %}


### PR DESCRIPTION
### What changed

Added role = "complementary" to phase banner so that all elements in a basic page are contained in landmarks

### Why did it change

So that pages meet WCAG accessibility requirements

- [LIME-86](https://govukverify.atlassian.net/browse/LIME-86)

