### PR TITLE
Bugfix: Script fails when the field is empty on both files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "di-ipv-cri-common-express",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "User interface for the Identity Proofing and Verification (IPV) system within the GDS digital identity platform, GOV.UK Sign In.",
   "main": "src/index.js",
   "engines": {

--- a/scripts/checkTranslations.js
+++ b/scripts/checkTranslations.js
@@ -6,25 +6,28 @@ const Backend = require("i18next-fs-backend");
 
 const SCRIPT_NAME = "TRANSLATION CHECK -";
 
-const foundLanguages = readdirSync(join(__dirname, "../../../src/locales")).filter(
+const fileLoc = process.argv[2] ? process.argv[2] : "../../../src/locales";
+
+const foundLanguages = readdirSync(join(__dirname, fileLoc)).filter(
   (fileName) => {
-    const joinedPath = join(join(__dirname, "../../../src/locales"), fileName);
+    const joinedPath = join(join(__dirname, fileLoc), fileName);
     const isDirectory = lstatSync(joinedPath).isDirectory();
     return isDirectory;
   }
 );
 
-const foundNamespaces = readdirSync(
-  join(__dirname, "../../../src/locales/en")
-).reduce((collection, fileName) => {
-  const joinedPath = join(join(__dirname, "../../../src/locales/en"), fileName);
-  const isFile = lstatSync(joinedPath).isFile();
-  if (isFile) {
-    collection.push(parse(fileName).name);
-  }
+const foundNamespaces = readdirSync(join(__dirname, `${fileLoc}/en`)).reduce(
+  (collection, fileName) => {
+    const joinedPath = join(join(__dirname, `${fileLoc}/en`), fileName);
+    const isFile = lstatSync(joinedPath).isFile();
+    if (isFile) {
+      collection.push(parse(fileName).name);
+    }
 
-  return collection;
-}, []);
+    return collection;
+  },
+  []
+);
 
 // set up i18next on the backedn with saveMissing set to true.
 i18next.use(Backend).init({
@@ -35,7 +38,7 @@ i18next.use(Backend).init({
   ns: foundNamespaces,
   defaultNS: "default",
   backend: {
-    loadPath: join(__dirname, "../../../src/locales/{{lng}}/{{ns}}.yml"),
+    loadPath: join(__dirname, `${fileLoc}/{{lng}}/{{ns}}.yml`),
   },
   saveMissingTo: "current",
 });

--- a/scripts/checkTranslations.js
+++ b/scripts/checkTranslations.js
@@ -46,8 +46,20 @@ function compareContent(set1, set2, parent) {
   const issues = [];
   const warnings = [];
   for (const key of Object.keys(set1)) {
-    const set1Field = set1[key];
-    const set2Field = set2[key];
+    let set1Field = set1[key];
+    let set2Field = set2[key];
+
+    // Thankful for the poor JS null/undefined system.
+    // Null = field exists but no value.
+    // undefined = field does not exist...
+    // This should catch where we have empty "hint" fields.
+    if (set1Field === null && set1Field !== undefined) {
+      set1Field = "_";
+    }
+
+    if (set2Field === null && set1Field !== undefined) {
+      set2Field = "_";
+    }
 
     if (!set2Field) {
       // example:

--- a/scripts/checkTranslations.test.js
+++ b/scripts/checkTranslations.test.js
@@ -1,0 +1,65 @@
+const { expect } = require("chai");
+const util = require("util");
+const exec = util.promisify(require("child_process").exec);
+
+describe("checkTranslation", () => {
+  it("should read the translated files and output logs for what are missing", async () => {
+    try {
+      await exec("node ./scripts/checkTranslations.js ./testFiles/fail");
+      expect.fail("CheckTranslations failed to fail");
+    } catch (failOutput) {
+      // extract logs from output.
+      const logs = failOutput.stdout.split("\n");
+      const warnings = logs.filter((val) => val.includes("warning"));
+      const errors = logs.filter(
+        (val) => val.includes("error") || val.includes("Missing")
+      );
+      // remove descriptive logs
+      warnings.shift();
+      errors.shift();
+
+      expect(warnings.length).to.equal(2);
+
+      for (const message of warnings) {
+        expect(message).to.contain("warning");
+        expect(message).to.contain("length do not match");
+      }
+
+      expect(errors.length).to.equal(4);
+
+      for (const message of errors) {
+        expect(message).to.satisfy((val) => {
+          if (val.includes("ENGLISH - Missing default.root.field3")) {
+            return true;
+          } else if (
+            val.includes(
+              "ENGLISH - Missing default.root.nest.nest2.nestIsDifferent"
+            )
+          ) {
+            return true;
+          } else if (val.includes("WELSH - Missing default.root.field2")) {
+            return true;
+          } else if (
+            val.includes("WELSH - Missing default.root.nest.nest2.nest3")
+          ) {
+            return true;
+          } else {
+            return false;
+          }
+        });
+      }
+    }
+  });
+
+  it("should pass with no errors", async () => {
+    const output = await exec(
+      "node ./scripts/checkTranslations.js ./testFiles/success"
+    );
+    const stout = output.stdout.split("/n");
+    const successMessage = !!stout.filter((val) =>
+      val.includes("Translation files look good")
+    );
+
+    expect(successMessage).to.be.true;
+  });
+});

--- a/scripts/testFiles/fail/cy/default.yml
+++ b/scripts/testFiles/fail/cy/default.yml
@@ -1,0 +1,17 @@
+root:
+  field1: "im field1"
+  field3: "im filed3"
+  array1:
+   - "value1"
+   - "value2"
+   - "value3"
+  array2:
+   - "value1"
+   - "value2"
+   - "MoreHere"
+  nest:
+    nest2:
+      nestIsDifferent: "diff"
+  empty:
+  empty2: null
+  empty3: "Am I?"

--- a/scripts/testFiles/fail/en/default.yml
+++ b/scripts/testFiles/fail/en/default.yml
@@ -1,0 +1,16 @@
+root:
+  field1: "im field1"
+  field2: "im filed2"
+  array1:
+   - "value1"
+   - "value2"
+   - "value3"
+  array2:
+   - "value1"
+   - "value2"
+  nest:
+    nest2:
+      nest3: "check"
+  empty:
+  empty2: null
+  empty3:

--- a/scripts/testFiles/success/cy/default.yml
+++ b/scripts/testFiles/success/cy/default.yml
@@ -1,0 +1,9 @@
+root:
+  field1: "im field1"
+  array1:
+   - "value1"
+   - "value2"
+   - "value3"
+  nest:
+    nest2:
+      nest3: "diff"

--- a/scripts/testFiles/success/en/default.yml
+++ b/scripts/testFiles/success/en/default.yml
@@ -1,0 +1,9 @@
+root:
+  field1: "im field1"
+  array1:
+   - "value1"
+   - "value2"
+   - "value3"
+  nest:
+    nest2:
+      nest3: "diff"


### PR DESCRIPTION
## Proposed changes

### What changed

Adds a check to set the field to be a simple string when we know its a `null` and not a `undefined`. 

### Why did it change

When a yaml script has a empty field it registers it as missing and thus fails the check. This check adds a `_` when we see null. If the field is undefined, then the translation library has failed to find it. 

The bug occurred because we're only checking for truthiness of the field and not whether the field exists or not. For example if a key exists but the field is null, then it fails.