### PR TITLE
OJ-923 : Send client IP address from all CRI frontends

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "i18next-fs-backend": "^1.1.5",
     "i18next-http-middleware": "3.2.1",
     "i18next-sync-fs-backend": "1.1.1",
-    "lodash.differencewith": "4.5.0"
+    "lodash.differencewith": "4.5.0",
+    "lodash.frompairs": "4.0.1"
   }
 }

--- a/src/lib/axios.js
+++ b/src/lib/axios.js
@@ -2,6 +2,8 @@ const axios = require("axios");
 
 const logger = require("hmpo-logger");
 
+const userIpAddress = require("./user-ip-address");
+
 module.exports = function (req, res, next) {
   const baseURL = req.app.get("API.BASE_URL");
 
@@ -22,6 +24,13 @@ module.exports = function (req, res, next) {
 
   if (req.scenarioIDHeader && req.axios?.defaults?.headers?.common) {
     req.axios.defaults.headers.common["x-scenario-id"] = req.scenarioIDHeader;
+  }
+
+  if (req?.headers["forwarded"] && req.axios?.defaults?.headers?.common) {
+    const ipAddress = userIpAddress(req.headers["forwarded"]);
+    if (ipAddress) {
+      req.axios.defaults.headers.common["x-forwarded-for"] = ipAddress;
+    }
   }
 
   next();

--- a/src/lib/axios.test.js
+++ b/src/lib/axios.test.js
@@ -87,4 +87,52 @@ describe("axios", () => {
         .undefined;
     });
   });
+
+  context("with 'x-forwarded-for'", () => {
+    it("should add x-forwarded-for to axios headers", () => {
+      axiosClient.defaults = { headers: { common: {} } };
+
+      req.headers["forwarded"] =
+        "for=192.0.2.0;host=subdomain.example.gov.uk;proto=http";
+
+      axios(req, res, next);
+
+      expect(req.axios.defaults.headers.common["x-forwarded-for"]).to.equal(
+        "192.0.2.0"
+      );
+    });
+  });
+
+  context("without 'x-forwarded-for'", () => {
+    it("should not x-forwarded-for to axios headers", () => {
+      delete req.headers["forwarded"];
+
+      axios(req, res, next);
+
+      expect(req.axios?.defaults?.headers?.common?.["x-forwarded-for"]).to.be
+        .undefined;
+    });
+    it("should not x-forwarded-for to axios headers while header is null", () => {
+      delete axiosClient.defaults;
+      req.headers["forwarded"] = null;
+
+      axios(req, res, next);
+
+      expect(req.axios?.defaults?.headers?.common?.["x-forwarded-for"]).to.be
+        .undefined;
+    });
+  });
+
+  context("without defaults'", () => {
+    it("should not x-forwarded-for to axios headers", () => {
+      delete axiosClient.defaults;
+      req.headers["forwarded"] =
+        "for=192.0.2.0;host=subdomain.example.gov.uk;proto=http";
+
+      axios(req, res, next);
+
+      expect(req.axios?.defaults?.headers?.common?.["x-forwarded-for"]).to.be
+        .undefined;
+    });
+  });
 });

--- a/src/lib/user-ip-address.js
+++ b/src/lib/user-ip-address.js
@@ -1,0 +1,10 @@
+const net = require("net");
+const fromPairs = require("lodash.frompairs");
+
+module.exports = (forwarded) => {
+  const forwardedHeaders = fromPairs(
+    forwarded?.split(";").map((s) => s.split("="))
+  );
+  const clientIp = forwardedHeaders?.for?.toString().trim();
+  return net.isIPv4(clientIp) || net.isIPv6(clientIp) ? clientIp : null;
+};

--- a/src/lib/user-ip-address.test.js
+++ b/src/lib/user-ip-address.test.js
@@ -1,0 +1,57 @@
+const userIpAddress = require("./user-ip-address");
+
+describe("user ip address", () => {
+  context("without ip header", () => {
+    it("should return null when passing req but with req.headers as null", () => {
+      const forwarded = null;
+      const ipAddress = userIpAddress(forwarded);
+
+      expect(ipAddress).to.equal(null);
+    });
+  });
+
+  context("with ip header", () => {
+    it("should return Ip Address in forwarded header", () => {
+      const forwarded =
+        "for=192.0.2.0;host=subdomain.example.gov.uk;proto=https";
+
+      const ipAddress = userIpAddress(forwarded);
+
+      expect(ipAddress).to.equal("192.0.2.0");
+    });
+
+    it("should return forwarded header with ipV4 address", () => {
+      const forwarded =
+        "host=subdomain.example.gov.uk;for=  192.0.2.0  ;proto=https";
+
+      const ipAddress = userIpAddress(forwarded);
+
+      expect(ipAddress).to.equal("192.0.2.0");
+    });
+
+    it("should return forwarded header with ipV6 address", () => {
+      const forwarded =
+        "host=subdomain.example.gov.uk;for=2001:db8:3333:4444:5555:6666:7777:8888;proto=https";
+
+      const ipAddress = userIpAddress(forwarded);
+
+      expect(ipAddress).to.equal("2001:db8:3333:4444:5555:6666:7777:8888");
+    });
+
+    it("should return null address when we have no for iteam", () => {
+      const forwarded = "host=subdomain.example.gov.uk;proto=https";
+
+      const ipAddress = userIpAddress(forwarded);
+
+      expect(ipAddress).to.equal(null);
+    });
+
+    it("should return null address when we have empty ip address in for item", () => {
+      const forwarded = "host=subdomain.example.gov.uk;for=;proto=https";
+
+      const ipAddress = userIpAddress(forwarded);
+
+      expect(ipAddress).to.equal(null);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2086,6 +2086,11 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
+lodash.frompairs@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz#bc4e5207fa2757c136e573614e9664506b2b1bd2"
+  integrity sha512-dvqe2I+cO5MzXCMhUnfYFa9MD+/760yx2aTAN1lqEcEkf896TxgrX373igVdqSJj6tQd0jnSLE1UMuKufqqxFw==
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"


### PR DESCRIPTION
## Proposed changes
Get Client IP address and send it to backend via Session API header. 
used "x-forwarded-for"  header value from /session api.

### What changed

Get Client IP Address and assigned the IP address on  header "x-forwarded-for" for session API .

### Why did it change

To reuse Client IP address of client to send to TXMA.


### Issue tracking

- [OJ-924](https://govukverify.atlassian.net/browse/OJ-923)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks