### PR TITLE
refactor: Send session_id & session-id for BE refactoring

### DIFF
--- a/src/routes/oauth2/middleware.js
+++ b/src/routes/oauth2/middleware.js
@@ -77,6 +77,7 @@ module.exports = {
         },
         headers: {
           "session-id": req.session.tokenId,
+          session_id: req.session.tokenId,
         },
       });
 

--- a/src/routes/oauth2/middleware.test.js
+++ b/src/routes/oauth2/middleware.test.js
@@ -291,7 +291,10 @@ describe("oauth middleware", () => {
             scope: "openid",
             state: req.session.authParams.state,
           },
-          headers: { "session-id": req.session.tokenId },
+          headers: {
+            "session-id": req.session.tokenId,
+            session_id: req.session.tokenId,
+          },
         });
       });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

There is currently an inconsistency with the common API endpoints - some of them use `session-id` and some of them use `session_id`.

In order to non-breaking refactoring on the API - all the API requests will temporarily provide both parameters. Once the refactoring is complete, the unused parameter can be removed.


<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-962](https://govukverify.atlassian.net/browse/OJ-962)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
