### PR TITLE
LIME-147 - Updating Error handling for access denied oauth error

### DIFF
--- a/src/lib/error-handling.js
+++ b/src/lib/error-handling.js
@@ -13,10 +13,15 @@ module.exports = {
     let redirect_uri = req.session.authParams.redirect_uri;
 
     if (err.isAxiosError) {
-      const oauthError = err?.response?.data?.oauth_error;
+      const errorResponse = err?.response?.data;
 
-      error.code = oauthError?.error || error.code;
-      error.description = oauthError?.error_description || error.description;
+      error.code =
+        errorResponse?.oauth_error?.error || errorResponse?.code || error.code;
+      error.description =
+        errorResponse?.oauth_error?.error_description ||
+        errorResponse?.message ||
+        error.description;
+
       redirect_uri = err?.response?.data?.redirect_uri || redirect_uri;
     }
 

--- a/src/lib/error-handling.test.js
+++ b/src/lib/error-handling.test.js
@@ -24,6 +24,157 @@ describe("error-handling", () => {
     oAuthStub.buildRedirectUrl = sinon.stub();
   });
 
+  describe("redirectAsErrorToCallbackWithoutOauthPrefix", () => {
+    context("with Axios error", () => {
+      beforeEach(() => {
+        err = {
+          isAxiosError: true,
+          response: {
+            data: {
+              redirect_uri: "http://error.example.org",
+              message: "Invalid request JWT",
+              code: "invalid_request_object",
+            },
+          },
+        };
+      });
+
+      it("should override error code if provided in response body without Oauth Prefix", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              error: {
+                code: "invalid_request_object",
+              },
+            },
+          })
+        );
+      });
+
+      it("should override error description if provided in response body without Oauth Prefix", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              error: {
+                description: "Invalid request JWT",
+              },
+            },
+          })
+        );
+      });
+
+      it("should override redirect_uri if provided in response body without Oauth Prefix", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              redirect_uri: "http://error.example.org",
+            },
+          })
+        );
+      });
+
+      it("should use a default for error code", async () => {
+        delete err.response.data.code;
+
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              error: {
+                code: "server_error",
+              },
+            },
+          })
+        );
+      });
+      it("should use a default for error description", async () => {
+        delete err.response.data.message;
+
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              error: {
+                description: "general error",
+              },
+            },
+          })
+        );
+      });
+      it("should use a default for redirect_uri", async () => {
+        delete err.response.data.redirect_uri;
+
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              redirect_uri: "http://example.org",
+            },
+          })
+        );
+      });
+    });
+
+    context("with default Error object", () => {
+      beforeEach(async () => {
+        err = new Error("error message");
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should build redirect with default error code and description", () => {
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith({
+          authParams: {
+            error: { code: "server_error", description: "general error" },
+            redirect_uri: "http://example.org",
+          },
+        });
+      });
+    });
+
+    context("with valid redirect url", () => {
+      beforeEach(async () => {
+        err = new Error("error message");
+        oAuthStub.buildRedirectUrl.returns("http://example.org");
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should call res.redirect with redirect_uri", () => {
+        expect(res.redirect).to.have.been.calledWith("http://example.org");
+      });
+
+      it("should not call next", () => {
+        expect(next).not.to.have.been.called;
+      });
+    });
+
+    context("with invalid redirect url", () => {
+      beforeEach(async () => {
+        err = new Error("error message");
+        req.session.authParams.redirect_uri = "not-a-url";
+        oAuthStub.buildRedirectUrl.throws("parse error");
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should not call res.redirect", () => {
+        expect(res.redirect).not.to.have.been.called;
+      });
+      it("should call next with err", () => {
+        expect(next).to.have.been.calledWith(err);
+      });
+    });
+  });
+
   describe("redirectAsErrorToCallback", () => {
     context("with Axios error", () => {
       beforeEach(() => {


### PR DESCRIPTION
### What changed

Oauth error handling

### Why did it change

To take in error code and description properly, and return access denied oauth error for integration with CRI callback to ipv core (e.g when a user escapes there journey in driving licence cri)