### PR TITLE
feat: Add plurals support to checkTranslations script

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "hmpo-logger": "6.1.1",
     "i18next": "^21.9.2",
-    "i18next-fs-backend": "^1.1.5"
+    "i18next-fs-backend": "^1.1.5",
+    "lodash.differencewith": "4.5.0"
   }
 }

--- a/scripts/checkTranslations.test.js
+++ b/scripts/checkTranslations.test.js
@@ -62,4 +62,16 @@ describe("checkTranslation", () => {
 
     expect(successMessage).to.be.true;
   });
+
+  it("should pass plurals with no errors", async () => {
+    const output = await exec(
+      "node ./scripts/checkTranslations.js ./testFiles/plurals"
+    );
+    const stout = output.stdout.split("/n");
+    const successMessage = !!stout.filter((val) =>
+      val.includes("Translation files look good")
+    );
+
+    expect(successMessage).to.be.true;
+  });
 });

--- a/scripts/testFiles/plurals/cy/default.yml
+++ b/scripts/testFiles/plurals/cy/default.yml
@@ -1,0 +1,7 @@
+root:
+  valueWithCount_zero: "{{ count }} value"
+  valueWithCount_one: "{{ count }} values"
+  valueWithCount_two: "{{ count }} values"
+  valueWithCount_few: "{{ count }} values"
+  valueWithCount_many: "{{ count }} values"
+  valueWithCount_other: "{{ count }} values"

--- a/scripts/testFiles/plurals/en/default.yml
+++ b/scripts/testFiles/plurals/en/default.yml
@@ -1,0 +1,4 @@
+root:
+  valueWithCount_zero: "{{ count }} value"
+  valueWithCount_one: "{{ count }} values"
+  valueWithCount_other: "{{ count }} values"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2050,6 +2050,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.differencewith@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz#bafafbc918b55154e179176a00bb0aefaac854b7"
+  integrity sha512-/8JFjydAS+4bQuo3CpLMBv7WxGFyk7/etOAsrQUCu0a9QVDemxv0YQ0rFyeZvqlUD314SERfNlgnlqqHmaQ0Cg==
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- i18next provides support for plurals, but plural forms differ between languages

https://www.unicode.org/cldr/cldr-aux/charts/29/supplemental/language_plural_rules.html

lodash.differenceWith is used to apply a set difference over the language keys

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
