### PR TITLE
fix: Use router not app for i18next

### DIFF
--- a/src/lib/i18next/index.js
+++ b/src/lib/i18next/index.js
@@ -1,9 +1,9 @@
 const { handler } = require("./handler");
 const { replaceTranslate } = require("./replace-translate");
 
-const setI18n = ({ app, config }) => {
-  app.use(handler(config));
-  app.use(replaceTranslate);
+const setI18n = ({ router, config }) => {
+  router.use(handler(config));
+  router.use(replaceTranslate);
 };
 
 module.exports = {

--- a/src/lib/i18next/index.test.js
+++ b/src/lib/i18next/index.test.js
@@ -12,18 +12,18 @@ const { setI18n } = proxyquire("./", {
 });
 
 describe("i18next", () => {
-  let app;
+  let router;
   let config;
 
   beforeEach(() => {
-    app = { use: sinon.stub() };
+    router = { use: sinon.stub() };
     config = { key: "value" };
 
-    setI18n({ app, config });
+    setI18n({ router, config });
   });
 
   it("should use handler", () => {
-    const handlerCall = app.use.getCall(0);
+    const handlerCall = router.use.getCall(0);
 
     expect(handlerCall).to.have.been.calledWithExactly("handler function");
   });
@@ -31,7 +31,7 @@ describe("i18next", () => {
     expect(handler).to.have.been.calledWithExactly(config);
   });
   it("should use replaceTranslate", () => {
-    const replaceCall = app.use.getCall(1);
+    const replaceCall = router.use.getCall(1);
 
     expect(replaceCall).to.have.been.calledWithExactly(replaceTranslate);
   });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

i18next needs to be set on the main router, not on the app as received from the bootstrap.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-XXXX](https://govukverify.atlassian.net/browse/KBV-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
