### PR TITLE
Fix spelling error in translation key

### DIFF
--- a/src/components/banner.njk
+++ b/src/components/banner.njk
@@ -4,11 +4,11 @@
 {% endset %}
 
 {% set acceptHtml %}
-  <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookeBannerAccept.paragraph1' | translate }}<a class="govuk-link" href="https://signin.account.gov.uk/cookies">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookeBannerAccept.paragraph2' | translate }}</p>
+  <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookieBannerAccept.paragraph1' | translate }}<a class="govuk-link" href="https://signin.account.gov.uk/cookies">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookieBannerAccept.paragraph2' | translate }}</p>
 {% endset %}
 
 {% set rejectedHtml %}
-  <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookeBannerReject.paragraph1' | translate }}<a class="govuk-link" href="https://signin.account.gov.uk/cookies">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookeBannerReject.paragraph2' | translate }}</p>
+  <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookieBannerReject.paragraph1' | translate }}<a class="govuk-link" href="https://signin.account.gov.uk/cookies">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookieBannerReject.paragraph2' | translate }}</p>
 {% endset %}
 
 {{ govukCookieBanner({


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This change harmonises the `yaml` keys and the translation keys in the nunjucks files.

### What changed

A spelling mistake was corrected in the nunjucks files.

### Why did it change

So the user interface shows the correct information.
