### PR TITLE
BAU: remove extra en dash from page titles

### DIFF
--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -56,7 +56,6 @@
     <script type="text/javascript" src="/public/javascripts/cookies.js"></script>
     <script type="text/javascript" src="/public/javascripts/all.js"></script>
     <script type="text/javascript" src="/public/javascripts/application.js"></script>
-    <script type="text/javascript" {% if cspNonce %}
-            nonce='{{ cspNonce }}{% endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
+    <script type="text/javascript" {% if cspNonce %} nonce='{{ cspNonce }}{% endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
   {% endblock %}
 {% endblock %}

--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -4,16 +4,20 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 
+{%- block pageTitle %}
+    {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }}{{ " – " + govukServiceName | safe if govukServiceName !== " " }} – GOV.UK
+{%- endblock %}
+
 {% block header %}
-    {% block cookieBanner %}
-        {% include 'banner.njk' %}
-    {% endblock %}
+  {% block cookieBanner %}
+    {% include 'banner.njk' %}
+  {% endblock %}
 
   {% block govukHeader %}
     {{ govukHeader({
       homepageUrl: "https://www.gov.uk"
     }) }}
-  {%  endblock %}
+  {% endblock %}
 {% endblock %}
 
 {% block beforeContent %}
@@ -31,9 +35,9 @@
     {% if backLink %}
       {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
       <span id="back">{{ govukBackLink({
-        text: translate("govuk.backLink"),
-        href: backLink
-      }) }}</span>
+          text: translate("govuk.backLink"),
+          href: backLink
+        }) }}</span>
     {% endif %}
   {% endblock %}
 {% endblock %}
@@ -41,9 +45,9 @@
 {% set footerNavItems = translate("govuk.footerNavItems", { returnObjects: true }) %}
 {% block footer %}
   {{ govukFooter( {
-      meta:footerNavItems.meta,
-      contentLicence: translate("govuk.contentLicence", { returnObjects: true }),
-      copyright: translate("govuk.copyright", { returnObjects: true })
+    meta:footerNavItems.meta,
+    contentLicence: translate("govuk.contentLicence", { returnObjects: true }),
+    copyright: translate("govuk.copyright", { returnObjects: true })
   } ) }}
 {% endblock %}
 
@@ -52,6 +56,7 @@
     <script type="text/javascript" src="/public/javascripts/cookies.js"></script>
     <script type="text/javascript" src="/public/javascripts/all.js"></script>
     <script type="text/javascript" src="/public/javascripts/application.js"></script>
-    <script type="text/javascript" {% if cspNonce %} nonce='{{ cspNonce }}{%  endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
+    <script type="text/javascript" {% if cspNonce %}
+            nonce='{{ cspNonce }}{% endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
   {% endblock %}
 {% endblock %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -4,16 +4,21 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 
+{%- block pageTitle %}
+  {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }}{{ " – " + govukServiceName | safe if govukServiceName !== " " }} – GOV.UK
+{%- endblock %}
+
 {% block header %}
-    {% block cookieBanner %}
-        {% include 'banner.njk' %}
-    {% endblock %}
+
+  {% block cookieBanner %}
+    {% include 'banner.njk' %}
+  {% endblock %}
 
   {% block govukHeader %}
     {{ govukHeader({
       homepageUrl: "https://www.gov.uk"
     }) }}
-  {%  endblock %}
+  {% endblock %}
 {% endblock %}
 
 {% block beforeContent %}
@@ -21,19 +26,19 @@
     tag: {
       text: translate("govuk.phaseBanner.tag")
     },
-     html: translate("govuk.phaseBanner.content"),
-     attributes: {
-        "role": "complementary"
-     }
+    html: translate("govuk.phaseBanner.content"),
+    attributes: {
+      "role": "complementary"
+    }
   }) }}
 
   {% block backLink %}
     {% if backLink %}
       {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
       <span id="back">{{ govukBackLink({
-        text: translate("govuk.backLink"),
-        href: backLink
-      }) }}</span>
+          text: translate("govuk.backLink"),
+          href: backLink
+        }) }}</span>
     {% endif %}
   {% endblock %}
 {% endblock %}
@@ -41,9 +46,9 @@
 {% set footerNavItems = translate("govuk.footerNavItems", { returnObjects: true }) %}
 {% block footer %}
   {{ govukFooter( {
-      meta:footerNavItems.meta,
-      contentLicence: translate("govuk.contentLicence", { returnObjects: true }),
-      copyright: translate("govuk.copyright", { returnObjects: true })
+    meta:footerNavItems.meta,
+    contentLicence: translate("govuk.contentLicence", { returnObjects: true }),
+    copyright: translate("govuk.copyright", { returnObjects: true })
   } ) }}
 {% endblock %}
 
@@ -52,6 +57,7 @@
     <script type="text/javascript" src="/public/javascripts/cookies.js"></script>
     <script type="text/javascript" src="/public/javascripts/all.js"></script>
     <script type="text/javascript" src="/public/javascripts/application.js"></script>
-    <script type="text/javascript" {% if cspNonce %} nonce='{{ cspNonce }}{%  endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
+    <script type="text/javascript" {% if cspNonce %}
+            nonce='{{ cspNonce }}{% endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
   {% endblock %}
 {% endblock %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -57,7 +57,6 @@
     <script type="text/javascript" src="/public/javascripts/cookies.js"></script>
     <script type="text/javascript" src="/public/javascripts/all.js"></script>
     <script type="text/javascript" src="/public/javascripts/application.js"></script>
-    <script type="text/javascript" {% if cspNonce %}
-            nonce='{{ cspNonce }}{% endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
+    <script type="text/javascript" {% if cspNonce %} nonce='{{ cspNonce }}{% endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
   {% endblock %}
 {% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR changes the format of the html `<title>` content to remove an extra en dash and space which is currently added if the `govukServiceName` variable is empty.

### What changed

A new `{% block pageTitle %}` block is added in `base-form.njk` and `base-page.njk` with an extra test for an empty string.

### Why did it change

Users may rely on the title tag to navigate through the journey using a screenreader or their browser history, so the title tag should be as legible as possible.

