### PR TITLE
Add language choice analytics

### DIFF
--- a/src/assets/javascript/.eslintrc.js
+++ b/src/assets/javascript/.eslintrc.js
@@ -3,6 +3,7 @@
 module.exports = {
   env: {
     browser: true,
+    es6: true,
   },
   globals: {
     "dataLayer": true,

--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -73,6 +73,26 @@ var cookies = function (trackingId, analyticsCookieDomain, journey) {
     initLinkerHandlers();
   }
 
+  function pushLanguageToDataLayer() {
+
+    const languageNames = {
+      'en':'english',
+      'cy':'welsh'
+    }
+
+    var languageCode = document.querySelector('html') &&
+      document.querySelector('html').getAttribute('lang');
+
+    if (languageCode) {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: "langEvent",
+        language: languageNames[languageCode],
+        languagecode: languageCode
+      });
+    }
+  }
+
   function loadGtmScript() {
     var gtmScriptTag = document.createElement("script");
     gtmScriptTag.type = "text/javascript";
@@ -107,6 +127,7 @@ var cookies = function (trackingId, analyticsCookieDomain, journey) {
       })
     }
 
+    pushLanguageToDataLayer();
     gtag({ "gtm.start": new Date().getTime(), event: "gtm.js" });
   }
 


### PR DESCRIPTION
## Proposed changes

Send the user’s language choice to Google Analytics

### What changed

Replicates the implementation found in core-front.

https://github.com/alphagov/di-ipv-core-front/commit/7feea5893e98b9b3083d5e8d14189100b1cd4d5a

https://github.com/alphagov/di-authentication-frontend/commit/74ebe4d7c64ea5643d387ee947dc0c6dc44eac5c

https://github.com/alphagov/di-ipv-core-front/pull/572

### Why did it change

To track users language choice.

es6: true - added to allow use of const in browser js.

### Issue tracking

- [LIME-250](https://govukverify.atlassian.net/browse/LIME-250)

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
