### PR TITLE
LIME-633 Fix typo in banner.njk (cookieBannerAccept/cookieBannerReject)

### DIFF
--- a/src/components/banner.njk
+++ b/src/components/banner.njk
@@ -4,11 +4,11 @@
 {% endset %}
 
 {% set acceptHtml %}
-  <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookeBannerAccept.paragraph1' | translate }}<a class="govuk-link" href="https://signin.account.gov.uk/cookies">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookeBannerAccept.paragraph2' | translate }}</p>
+  <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookieBannerAccept.paragraph1' | translate }}<a class="govuk-link" href="https://signin.account.gov.uk/cookies">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookieBannerAccept.paragraph2' | translate }}</p>
 {% endset %}
 
 {% set rejectedHtml %}
-  <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookeBannerReject.paragraph1' | translate }}<a class="govuk-link" href="https://signin.account.gov.uk/cookies">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookeBannerReject.paragraph2' | translate }}</p>
+  <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookieBannerReject.paragraph1' | translate }}<a class="govuk-link" href="https://signin.account.gov.uk/cookies">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookieBannerReject.paragraph2' | translate }}</p>
 {% endset %}
 
 {{ govukCookieBanner({

--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -56,7 +56,6 @@
     <script type="text/javascript" src="/public/javascripts/cookies.js"></script>
     <script type="text/javascript" src="/public/javascripts/all.js"></script>
     <script type="text/javascript" src="/public/javascripts/application.js"></script>
-    <script type="text/javascript" {% if cspNonce %}
-            nonce='{{ cspNonce }}{% endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
+    <script type="text/javascript" {% if cspNonce %} nonce='{{ cspNonce }}{% endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
   {% endblock %}
 {% endblock %}

--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -4,16 +4,20 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 
+{%- block pageTitle %}
+    {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }}{{ " – " + govukServiceName | safe if govukServiceName !== " " }} – GOV.UK
+{%- endblock %}
+
 {% block header %}
-    {% block cookieBanner %}
-        {% include 'banner.njk' %}
-    {% endblock %}
+  {% block cookieBanner %}
+    {% include 'banner.njk' %}
+  {% endblock %}
 
   {% block govukHeader %}
     {{ govukHeader({
       homepageUrl: "https://www.gov.uk"
     }) }}
-  {%  endblock %}
+  {% endblock %}
 {% endblock %}
 
 {% block beforeContent %}
@@ -31,9 +35,9 @@
     {% if backLink %}
       {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
       <span id="back">{{ govukBackLink({
-        text: translate("govuk.backLink"),
-        href: backLink
-      }) }}</span>
+          text: translate("govuk.backLink"),
+          href: backLink
+        }) }}</span>
     {% endif %}
   {% endblock %}
 {% endblock %}
@@ -41,9 +45,9 @@
 {% set footerNavItems = translate("govuk.footerNavItems", { returnObjects: true }) %}
 {% block footer %}
   {{ govukFooter( {
-      meta:footerNavItems.meta,
-      contentLicence: translate("govuk.contentLicence", { returnObjects: true }),
-      copyright: translate("govuk.copyright", { returnObjects: true })
+    meta:footerNavItems.meta,
+    contentLicence: translate("govuk.contentLicence", { returnObjects: true }),
+    copyright: translate("govuk.copyright", { returnObjects: true })
   } ) }}
 {% endblock %}
 
@@ -52,6 +56,7 @@
     <script type="text/javascript" src="/public/javascripts/cookies.js"></script>
     <script type="text/javascript" src="/public/javascripts/all.js"></script>
     <script type="text/javascript" src="/public/javascripts/application.js"></script>
-    <script type="text/javascript" {% if cspNonce %} nonce='{{ cspNonce }}{%  endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
+    <script type="text/javascript" {% if cspNonce %}
+            nonce='{{ cspNonce }}{% endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
   {% endblock %}
 {% endblock %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -4,16 +4,21 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 
+{%- block pageTitle %}
+  {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }}{{ " – " + govukServiceName | safe if govukServiceName !== " " }} – GOV.UK
+{%- endblock %}
+
 {% block header %}
-    {% block cookieBanner %}
-        {% include 'banner.njk' %}
-    {% endblock %}
+
+  {% block cookieBanner %}
+    {% include 'banner.njk' %}
+  {% endblock %}
 
   {% block govukHeader %}
     {{ govukHeader({
       homepageUrl: "https://www.gov.uk"
     }) }}
-  {%  endblock %}
+  {% endblock %}
 {% endblock %}
 
 {% block beforeContent %}
@@ -21,19 +26,19 @@
     tag: {
       text: translate("govuk.phaseBanner.tag")
     },
-     html: translate("govuk.phaseBanner.content"),
-     attributes: {
-        "role": "complementary"
-     }
+    html: translate("govuk.phaseBanner.content"),
+    attributes: {
+      "role": "complementary"
+    }
   }) }}
 
   {% block backLink %}
     {% if backLink %}
       {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
       <span id="back">{{ govukBackLink({
-        text: translate("govuk.backLink"),
-        href: backLink
-      }) }}</span>
+          text: translate("govuk.backLink"),
+          href: backLink
+        }) }}</span>
     {% endif %}
   {% endblock %}
 {% endblock %}
@@ -41,9 +46,9 @@
 {% set footerNavItems = translate("govuk.footerNavItems", { returnObjects: true }) %}
 {% block footer %}
   {{ govukFooter( {
-      meta:footerNavItems.meta,
-      contentLicence: translate("govuk.contentLicence", { returnObjects: true }),
-      copyright: translate("govuk.copyright", { returnObjects: true })
+    meta:footerNavItems.meta,
+    contentLicence: translate("govuk.contentLicence", { returnObjects: true }),
+    copyright: translate("govuk.copyright", { returnObjects: true })
   } ) }}
 {% endblock %}
 
@@ -52,6 +57,7 @@
     <script type="text/javascript" src="/public/javascripts/cookies.js"></script>
     <script type="text/javascript" src="/public/javascripts/all.js"></script>
     <script type="text/javascript" src="/public/javascripts/application.js"></script>
-    <script type="text/javascript" {% if cspNonce %} nonce='{{ cspNonce }}{%  endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
+    <script type="text/javascript" {% if cspNonce %}
+            nonce='{{ cspNonce }}{% endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
   {% endblock %}
 {% endblock %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -57,7 +57,6 @@
     <script type="text/javascript" src="/public/javascripts/cookies.js"></script>
     <script type="text/javascript" src="/public/javascripts/all.js"></script>
     <script type="text/javascript" src="/public/javascripts/application.js"></script>
-    <script type="text/javascript" {% if cspNonce %}
-            nonce='{{ cspNonce }}{% endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
+    <script type="text/javascript" {% if cspNonce %} nonce='{{ cspNonce }}{% endif %}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}", "{{ gtmJourney }}")</script>
   {% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Proposed changes

### What changed

Correct a typo in banner.njk (cookieBannerAccept/cookieBannerReject)

PR amended to use the same fix by @wilsond-gds https://github.com/alphagov/di-ipv-cri-common-express/pull/166 and also apply https://github.com/alphagov/di-ipv-cri-common-express/pull/167

### Why did it change

Missing text in Driving License/Passport-v1 fronts was traced to a typo that had been replicated though existing CRI front ends.

### Issue tracking

- [LIME-633](https://govukverify.atlassian.net/browse/LIME-633)
- [LIME-665](https://govukverify.atlassian.net/browse/LIME-665)

[LIME-633]: https://govukverify.atlassian.net/browse/LIME-633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIME-665]: https://govukverify.atlassian.net/browse/LIME-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ